### PR TITLE
Create items model and around

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -77,3 +77,7 @@ gem "active_hash"
 
 # include ancestry gem, Referenced ancestry README.md
 gem "ancestry"
+
+# include carrierwave gem
+gem 'carrierwave'
+gem 'mini_magick'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,6 +95,13 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (~> 1.5)
       xpath (~> 3.2)
+    carrierwave (2.1.0)
+      activemodel (>= 5.0.0)
+      activesupport (>= 5.0.0)
+      addressable (~> 2.6)
+      image_processing (~> 1.1)
+      mimemagic (>= 0.3.0)
+      mini_mime (>= 0.1.3)
     childprocess (3.0.0)
     coderay (1.1.3)
     concurrent-ruby (1.1.6)
@@ -120,6 +127,9 @@ GEM
       ruby_parser (~> 3.5)
     i18n (1.8.5)
       concurrent-ruby (~> 1.0)
+    image_processing (1.11.0)
+      mini_magick (>= 4.9.5, < 5)
+      ruby-vips (>= 2.0.17, < 3)
     jbuilder (2.10.0)
       activesupport (>= 5.0.0)
     kgio (2.11.3)
@@ -136,6 +146,7 @@ GEM
       mimemagic (~> 0.3.2)
     method_source (1.0.0)
     mimemagic (0.3.5)
+    mini_magick (4.10.1)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.14.1)
@@ -191,6 +202,8 @@ GEM
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     regexp_parser (1.7.1)
+    ruby-vips (2.0.17)
+      ffi (~> 1.9)
     ruby_dep (1.5.0)
     ruby_parser (3.14.2)
       sexp_processor (~> 4.9)
@@ -273,9 +286,11 @@ DEPENDENCIES
   capistrano-rbenv
   capistrano3-unicorn
   capybara (>= 2.15)
+  carrierwave
   haml-rails (~> 2.0)
   jbuilder (~> 2.7)
   listen (>= 3.0.5, < 3.2)
+  mini_magick
   mysql2 (>= 0.4.4)
   pry-rails
   puma (~> 3.11)

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 |category_id|integer|null: false, foreign_key: true|
 |phase_id|integer|null: false, foreign_key: true|
 |status_id|integer|null: false, foreign_key: true|
-|delivery_to_pay_id|string|null: false, foreign_key: true|
+|delivery_to_pay_id|integer|null: false, foreign_key: true|
 |name|string|null: false|
 |price|integer|null: false|
 |item_detail|text||

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,0 +1,2 @@
+class Category < ApplicationRecord
+end

--- a/app/models/delivery_to_pay.rb
+++ b/app/models/delivery_to_pay.rb
@@ -1,5 +1,5 @@
-class Phase < ActiveHash::Base
+class DeliveryToPay < ActiveHash::Base
   self.data = [
-      {id: 1, to_pay: '送料込み(出品者負担)'}, {id: 2, status: '着払い(購入者負担)'}
+      {id: 1, to_pay: '送料込み(出品者負担)'}, {id: 2, to_pay: '着払い(購入者負担)'}
   ]
 end

--- a/app/models/delivery_to_pay.rb
+++ b/app/models/delivery_to_pay.rb
@@ -1,0 +1,5 @@
+class Phase < ActiveHash::Base
+  self.data = [
+      {id: 1, to_pay: '送料込み(出品者負担)'}, {id: 2, status: '着払い(購入者負担)'}
+  ]
+end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,0 +1,10 @@
+class Item < ApplicationRecord
+  has_many :item_images
+  has_many :messages
+  belongs_to :sell_user, class_name: "User"
+  belongs_to :buy_user, class_name: "User"
+  belongs_to_active_hash :phase
+  belongs_to_active_hash :status
+  belongs_to_active_hash :delivery_to_pay
+  belongs_to :category
+end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,4 +1,5 @@
 class Item < ApplicationRecord
+  extend ActiveHash::Associations::ActiveRecordExtensions
   has_many :item_images
   has_many :messages
   belongs_to :sell_user, class_name: "User"

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -7,4 +7,8 @@ class Item < ApplicationRecord
   belongs_to_active_hash :status
   belongs_to_active_hash :delivery_to_pay
   belongs_to :category
+
+  validates :name, presence: true
+  validates :price, presence: true
+  validates :delivery_days, presence: true
 end

--- a/app/models/item_image.rb
+++ b/app/models/item_image.rb
@@ -1,0 +1,3 @@
+class ItemImage < ApplicationRecord
+  belongs_to :item
+end

--- a/app/models/item_image.rb
+++ b/app/models/item_image.rb
@@ -1,3 +1,5 @@
 class ItemImage < ApplicationRecord
   belongs_to :item
+
+  validates :image, presence: true, uniquness: {scope: [:item, :image]}
 end

--- a/app/models/item_image.rb
+++ b/app/models/item_image.rb
@@ -2,4 +2,6 @@ class ItemImage < ApplicationRecord
   belongs_to :item
 
   validates :image, presence: true, uniquness: {scope: [:item, :image]}
+
+  mount_uploader :image, ImageUploader
 end

--- a/app/models/phase.rb
+++ b/app/models/phase.rb
@@ -1,0 +1,6 @@
+class Phase < ActiveHash::Base
+  self.data = [
+      {id: 1, phase: '出品中'}, {id: 2, phase: '支払い待ち'}, {id: 3, name: '発送待ち'},
+      {id: 4, phase: '取引完了'}
+  ]
+end

--- a/app/models/phase.rb
+++ b/app/models/phase.rb
@@ -1,6 +1,6 @@
 class Phase < ActiveHash::Base
   self.data = [
-      {id: 1, phase: '出品中'}, {id: 2, phase: '支払い待ち'}, {id: 3, name: '発送待ち'},
+      {id: 1, phase: '出品中'}, {id: 2, phase: '支払い待ち'}, {id: 3, phase: '発送待ち'},
       {id: 4, phase: '取引完了'}
   ]
 end

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -1,6 +1,6 @@
-class Phase < ActiveHash::Base
+class Status < ActiveHash::Base
   self.data = [
-      {id: 1, status: '新品、未使用'}, {id: 2, status: '未使用に近い'}, {id: 3, name: '目立った傷や汚れなし'},
+      {id: 1, status: '新品、未使用'}, {id: 2, status: '未使用に近い'}, {id: 3, status: '目立った傷や汚れなし'},
       {id: 4, status: 'やや傷や汚れあり'}, {id: 5, status: '傷や汚れあり'}, {id: 6, status: '全体的に状態が悪い'}
   ]
 end

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -1,0 +1,6 @@
+class Phase < ActiveHash::Base
+  self.data = [
+      {id: 1, status: '新品、未使用'}, {id: 2, status: '未使用に近い'}, {id: 3, name: '目立った傷や汚れなし'},
+      {id: 4, status: 'やや傷や汚れあり'}, {id: 5, status: '傷や汚れあり'}, {id: 6, status: '全体的に状態が悪い'}
+  ]
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,2 @@
+class User < ApplicationRecord
+end

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -1,0 +1,47 @@
+class ImageUploader < CarrierWave::Uploader::Base
+  # Include RMagick or MiniMagick support:
+  # include CarrierWave::RMagick
+  include CarrierWave::MiniMagick
+
+  # Choose what kind of storage to use for this uploader:
+  storage :file
+  # storage :fog
+
+  # Override the directory where uploaded files will be stored.
+  # This is a sensible default for uploaders that are meant to be mounted:
+  def store_dir
+    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+  end
+
+  # Provide a default URL as a default if there hasn't been a file uploaded:
+  # def default_url(*args)
+  #   # For Rails 3.1+ asset pipeline compatibility:
+  #   # ActionController::Base.helpers.asset_path("fallback/" + [version_name, "default.png"].compact.join('_'))
+  #
+  #   "/images/fallback/" + [version_name, "default.png"].compact.join('_')
+  # end
+
+  # Process files as they are uploaded:
+  # process scale: [200, 300]
+  #
+  # def scale(width, height)
+  #   # do something
+  # end
+
+  # Create different versions of your uploaded files:
+  # version :thumb do
+    process resize_to_fit: [80, 80]
+  # end
+
+  # Add a white list of extensions which are allowed to be uploaded.
+  # For images you might use something like this:
+  # def extension_whitelist
+  #   %w(jpg jpeg gif png)
+  # end
+
+  # Override the filename of the uploaded files:
+  # Avoid using model.id or version_name here, see uploader/store.rb for details.
+  # def filename
+  #   "something.jpg" if original_filename
+  # end
+end

--- a/db/migrate/20200807100656_create_users.rb
+++ b/db/migrate/20200807100656_create_users.rb
@@ -1,0 +1,8 @@
+class CreateUsers < ActiveRecord::Migration[6.0]
+  def change
+    create_table :users do |t|
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200807100739_create_categories.rb
+++ b/db/migrate/20200807100739_create_categories.rb
@@ -1,0 +1,8 @@
+class CreateCategories < ActiveRecord::Migration[6.0]
+  def change
+    create_table :categories do |t|
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200807100840_create_items.rb
+++ b/db/migrate/20200807100840_create_items.rb
@@ -1,0 +1,18 @@
+class CreateItems < ActiveRecord::Migration[6.0]
+  def change
+    create_table :items do |t|
+      t.references :sell_user, null: false, foreign_key: {to_table: :users}
+      t.references :buy_user, null: false, foreign_key: {to_table: :users}
+      t.references :category, null: false, foreign_key: true
+      t.integer :phase_id, null: false, foreign_key: true
+      t.integer :status_id, null: false, foreign_key: true
+      t.integer :delivery_to_pay_id, null: false, foreign_key: true
+      t.string :name, null: false
+      t.integer :price, null: false
+      t.text :item_detail
+      t.integer :delivery_days, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200807100950_create_item_images.rb
+++ b/db/migrate/20200807100950_create_item_images.rb
@@ -1,0 +1,10 @@
+class CreateItemImages < ActiveRecord::Migration[6.0]
+  def change
+    create_table :item_images do |t|
+      t.references :item, null: false, foreign_key: true
+      t.string :image, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200810072130_addindex_items.rb
+++ b/db/migrate/20200810072130_addindex_items.rb
@@ -1,0 +1,5 @@
+class AddindexItems < ActiveRecord::Migration[6.0]
+  def change
+    add_index :items, :name
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,15 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `rails
+# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 0) do
+
+end

--- a/test/fixtures/categories.yml
+++ b/test/fixtures/categories.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/fixtures/item_images.yml
+++ b/test/fixtures/item_images.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/fixtures/items.yml
+++ b/test/fixtures/items.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/category_test.rb
+++ b/test/models/category_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class CategoryTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/item_image_test.rb
+++ b/test/models/item_image_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class ItemImageTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/item_test.rb
+++ b/test/models/item_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class ItemTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class UserTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
# What
商品モデルと関連するモデルを作成
- itemsテーブル、item_imagesテーブルを作成するマイグレーションファイルを作成
- (usersマイグレーション, categoriesマイグレーションファイルは空で作成)
- itemモデル、item_imageモデルを作成
- active_hashを使用するモデル(phase,status,delivery_to_pay)を作成
- (usersモデル、categoryモデルは空で作成)
- itemモデルのRspecテストを実施(items-model-testブランチを参照)

# Why
- 商品に関わる機能(商品出品機能、商品購入機能、商品削除機能など)の元となるモデルとテーブルとなり、機能に重大な影響を与えるため

# Reference
Rspecテスト内容
- https://gyazo.com/c9f8d0dc19e8c62fa62e221fd30a5c5b

Rspecテスト結果
- https://gyazo.com/109e5d970708b198b594328acfdd87c6
